### PR TITLE
Fix work with matrix projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509.1</version><!-- which version of Jenkins is this plugin built against? -->
+		<version>1.565.3</version><!-- which version of Jenkins is this plugin built against? -->
 	</parent>
 
 	<licenses>
@@ -43,6 +43,14 @@
 		-->
 		<maven-hpi-plugin.version>1.95</maven-hpi-plugin.version>
 	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>matrix-project</artifactId>
+			<version>1.4</version>
+		</dependency>
+	</dependencies>
 
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Shared+workspace+plugin</url>
 

--- a/src/main/java/org/jenkinsci/plugins/sharedworkspace/PushWorkspaceURL.java
+++ b/src/main/java/org/jenkinsci/plugins/sharedworkspace/PushWorkspaceURL.java
@@ -7,20 +7,24 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Environment;
 import hudson.model.Run;
+import hudson.model.Job;
 import hudson.model.listeners.RunListener;
+import hudson.matrix.MatrixConfiguration;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 @Extension
 public class PushWorkspaceURL extends RunListener<AbstractBuild> {
-
 	@Override
 	public Environment setUpEnvironment(AbstractBuild build, Launcher launcher, BuildListener listener)
 		throws IOException, InterruptedException, Run.RunnerAbortedException
 	{
+		Job project = build.getProject();
+		if (project instanceof MatrixConfiguration)
+			project = ((MatrixConfiguration)project).getParent();
 		Map<String, String> map = new HashMap<String, String>();
-		SharedWorkspace sw = (SharedWorkspace) build.getProject().getProperty(SharedWorkspace.class);
+		SharedWorkspace sw = (SharedWorkspace) project.getProperty(SharedWorkspace.class);
 
 		if(sw != null && sw.getUrl() != null)
 			map.put("SHAREDSPACE_SCM_URL", sw.getUrl());


### PR DESCRIPTION
Shared workspace plugin do not set SCM URL environment variable to the MatrixConfiguration builds and they are failing when try to use this plugin with matrix projects. This commit fixes the issue.
